### PR TITLE
added modal fixes for firefox browser

### DIFF
--- a/client/src/app/desktop/desktop.component.ts
+++ b/client/src/app/desktop/desktop.component.ts
@@ -15,7 +15,7 @@ export class DesktopComponent implements AfterViewInit{
 
 	@ViewChild('container') input: ElementRef | undefined;
 
-	constructor(private renderer: Renderer2, public globals: Globals, private elRef: ElementRef) {
+	constructor(private renderer: Renderer2, public globals: Globals) {
 		this.fullScreen = this.globals.fullScreen;
 	}
 
@@ -34,7 +34,7 @@ export class DesktopComponent implements AfterViewInit{
 			div.style.borderRadius = '0.25rem'
 			this.input?.nativeElement.appendChild(div);
 		}
-
+		
 		//viselect
 		const selection = new SelectionArea({
 			selectables: [".container > div"],

--- a/client/src/app/modal/modal.component.html
+++ b/client/src/app/modal/modal.component.html
@@ -1,6 +1,6 @@
 <!--start moving and make active window-->
 <div
-(click)="open()">
+(click)="open();$event.stopPropagation();">
   <span class="window-action-btn">
     <img (click)="close();$event.stopPropagation()" src="../../assets/img/btn-close.svg" alt="btn-close-icon" />
   </span>
@@ -14,6 +14,7 @@
   	(mousedown)="startMove($event, 2)">
     <div class="window-head-draggable">
       <img
+		draggable="false"
         *ngIf="id == 'explorer'"
         src="../../assets/img/folder-home.svg"
         alt="folder-home-icon"
@@ -23,8 +24,10 @@
     </div>
   </div>
   <ng-content></ng-content>
+  <!--for webkit option draggable is false-->
   <img
-  	(mousedown)="startMove($event, 1)" 
+  	draggable="false"
+  	(mousedown)="startMove($event, 1)"
     class="ui-resizable-se"
     src="../../assets/img/app-resize-right.svg"
     alt="app-resize-icon"

--- a/client/src/app/modal/modal.component.sass
+++ b/client/src/app/modal/modal.component.sass
@@ -1,5 +1,32 @@
 app-modal
 	display: none
+	position: absolute
+	background: white
+	padding: 0
+	border: 1px solid #9a9a9a
+	box-shadow: 0 0 15px #00000066
+	overflow: hidden
+	border-radius: 4px
+	border: none
+	//smooth moving
+	transition: opacity 0.2s, margin-top 0.2s, margin-bottom 0.2s, margin-left 0.2s, margin-right 0.2s
+	-webkit-transition: opacity 0.2s, margin-top 0.2s, margin-bottom 0.2s, margin-left 0.2s, margin-right 0.2s
+	transform: none
+	user-select: none !important
+	-moz-user-select: none !important
+	-webkit-user-select: none
+	
+	//default values
+	z-index: 0
+	width: 600px
+	height: 350px
+	top: calc(15% + 0px)
+	left: 405px
+	min-width: 300px
+	min-height: 200px
+	
+	.focused
+		z-index: 1
 
 .scale-in-center
 	-webkit-animation: scale-in-center 0.5s cubic-bezier(0.250, 0.460, 0.450, 0.940) both

--- a/client/src/app/modal/modal.component.ts
+++ b/client/src/app/modal/modal.component.ts
@@ -54,6 +54,15 @@ export class ModalComponent implements OnInit, OnDestroy {
 		// add self (this modal instance) to the modal service so it's accessible from controllers
 		this.modalService.add(this);
 
+
+		//add precise eventListener
+		//const em = this.element.getElementById('app-resize-icon');
+		//em.addEventListener('mousedown', function handleClick(event: any) {
+		//	console.log('box clicked', event);
+		
+			//box.setAttribute('style', 'background-color: yellow;');
+		//});
+
 	}
 
 
@@ -79,7 +88,7 @@ export class ModalComponent implements OnInit, OnDestroy {
 		} else {
 
 			//open new window	
-			this.element.style.display = 'grid';
+			this.element.style.display = 'block';
 			this.setNewPosition(this.element);
 			this.element.classList.add('app-modal-opened');
 			this.element.classList.add('scale-in-center');
@@ -229,7 +238,8 @@ export class ModalComponent implements OnInit, OnDestroy {
 	 * moving modals
 	 * @param event 
 	 */
-	startMove(event: MouseEvent, status: number) {
+	startMove(event: any, status: number) {
+
 		if (status == 2) {
 			let target: any = event.currentTarget
 			let position = getPosition(target);
@@ -245,18 +255,38 @@ export class ModalComponent implements OnInit, OnDestroy {
 			this.resizing = true;
 		}
 
+		if(status == 0) {
+			event.stopPropagation();
+			this.resizing = false;
+			this.moving = false;
+		}
+
+	}
+	
+	
+	@HostListener("document:mousedown", ["$event"])
+	@HostListener("document:click", ["$event"])
+	down(event: any){
+		console.log('mouse down')
+		this.resizing = false;
 	}
 
+	
 	@HostListener("document:mousemove", ["$event"])
-	move(event: MouseEvent) {
 
-		if (this.moving) {
+	move(event: any) {
+
+		console.log(event.type)
+
+		if (this.moving && event.type != 'click') {
 			if (event.clientY - this.shift.y > 0 && event.clientX - this.shift.x > 0) {
+
 				this.element.style.top = (event.clientY - this.shift.y) + 'px';
 				this.element.style.left = (event.clientX - this.shift.x) + 'px';
 			}
 		}
-		if (this.resizing) {
+
+		if (this.resizing && event.type != 'click') {
 			if (event.clientY > 0 && event.clientX > 0) {
 				//find current left and top of the modal window
 				let top = this.element.getBoundingClientRect().top;
@@ -270,11 +300,13 @@ export class ModalComponent implements OnInit, OnDestroy {
 		}
 	}
 
+	
 	@HostListener("document:mouseup")
 	stopMove() {
 		this.moving = false;
 		this.resizing = false;
 	}
+	
 }
 
 

--- a/client/src/assets/css/components/window.sass
+++ b/client/src/assets/css/components/window.sass
@@ -1,28 +1,3 @@
-app-modal
-  position: absolute
-  background: white
-  padding: 0
-  border: 1px solid #9a9a9a
-  box-shadow: 0 0 15px #00000066
-  overflow: hidden
-  border-radius: 4px
-  border: none
-  transition: opacity .2s
-  user-select: none !important
-  -moz-user-select: none !important
-  -webkit-user-select: none
-  //default values
-  z-index: 0
-  width: 600px
-  height: 350px
-  display: block
-  top: calc(15% + 0px)
-  left: 405px
-  min-width: 300px
-  min-height: 200px
-.focused
-  z-index: 1
-
 .window-head
   overflow: hidden
   padding: 0
@@ -144,7 +119,11 @@ app-modal
   margin-left: 8px
   margin-top: 7px
   margin-right: -5px
-  filter: drop-shadow(0 0 0.5px rgb(51, 51, 51))
+  filter: drop-shadow(0 0 0.5px rgb(51, 51, 51))  
+  user-select: none !important
+  -moz-user-select: none !important
+  -webkit-user-select: none !important
+  -ms-user-select: none !important
 
 .window-navbar
   overflow: hidden


### PR DESCRIPTION
Fixed push-up effect for the resizeable icon in the Firefox browser. It depends on the parameter draggable="false". Css option "-webkit-user-drag: none"  or "-webkit-user-select:none" doesn't work of FF.